### PR TITLE
Localz logging

### DIFF
--- a/lib/Controllers/BaseController.js
+++ b/lib/Controllers/BaseController.js
@@ -7,7 +7,7 @@
 
 const _configuration = require('../configuration');
 const _crypto = require('crypto')
-const _logger = require('winston');
+const _logger = require('../LogConfig').getLogger();
 const _objectMapper = require('../ObjectMapper');
 
 const _objectMapperInstance = new _objectMapper();
@@ -16,7 +16,7 @@ class BaseController {
     static getSdkVersion()
     {
         return 'messagemedia-messages-nodejs-sdk-1.1.0';
-    } 
+    }
 
     /**
      * Get ObjectMapper instance
@@ -75,7 +75,7 @@ class BaseController {
     * Helper function to add the authentication headers
      * @param    {array}     options               The request options
      * @param    {array}     headers               The request headers
-     * @param    {string}    url                   The target url 
+     * @param    {string}    url                   The target url
      * @param    {string}    body                  The JSON body for the request
     */
     static applyAuthentication(options, headers, url, body)
@@ -87,6 +87,9 @@ class BaseController {
         }
         else
         {
+            if(_configuration.basicAuthUserName.length != 20 || _configuration.basicAuthPassword.length != 30) {
+              console.log('~~~~ It appears as though your REST API Keys are invalid. Please check and make sure they are correct. (Incorrect Length) ~~~~~')
+            }
             options["username"] = _configuration.basicAuthUserName;
             options["password"] = _configuration.basicAuthPassword;
         }

--- a/lib/Controllers/DeliveryReportsController.js
+++ b/lib/Controllers/DeliveryReportsController.js
@@ -9,7 +9,7 @@ const _request = require('../Http/Client/RequestClient');
 const _configuration = require('../configuration');
 const _apiHelper = require('../APIHelper');
 const _baseController = require('./BaseController');
-const _logger = require('winston');
+const _logger = require('../LogConfig').getLogger();
 
 class DeliveryReportsController {
     /**

--- a/lib/Controllers/MessagesController.js
+++ b/lib/Controllers/MessagesController.js
@@ -9,7 +9,7 @@ const _request = require('../Http/Client/RequestClient');
 const _configuration = require('../configuration');
 const _apiHelper = require('../APIHelper');
 const _baseController = require('./BaseController');
-const _logger = require('winston');
+const _logger = require('../LogConfig').getLogger();
 
 class MessagesController {
     /**

--- a/lib/Controllers/RepliesController.js
+++ b/lib/Controllers/RepliesController.js
@@ -9,7 +9,7 @@ const _request = require('../Http/Client/RequestClient');
 const _configuration = require('../configuration');
 const _apiHelper = require('../APIHelper');
 const _baseController = require('./BaseController');
-const _logger = require('winston');
+const _logger = require('../LogConfig').getLogger();
 
 class RepliesController {
     /**

--- a/lib/LogConfig.js
+++ b/lib/LogConfig.js
@@ -1,25 +1,28 @@
 
 'use strict';
 
-const logger = require('winston');
+const winston = require('winston');
+
+const LOGGER_NAME = 'messagemedia';
+
+const _container = new winston.Container();
 
 class LogConfig {
-    static LogConfig() {
-        logger.configure({
-            transports: [
-                new (logger.transports.Console)({
-                    level: 'info',
-                    colorize: true,
-                    timestamp: true,
-                }),
-                new (logger.transports.File)({
-                    filename: 'logfile.log',
-                    level: 'debug',
-                    colorize: true,
-                    timestamp: true,
-                }),
-            ],
+    static initialize() {
+        _container.add(LOGGER_NAME, {
+            console: {
+                level: 'debug',
+                label: 'MessageMedia SDK',
+            },
         });
+    }
+
+    static setLogLevel(logLevel = 'debug') {
+        _container.loggers[LOGGER_NAME].transports.console.level = logLevel;
+    }
+
+    static getLogger() {
+        return _container.get(LOGGER_NAME);
     }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,6 +50,6 @@ const initializer = {
     AuthHelper,
 };
 
-initializer.Logger.LogConfig();
+Logger.initialize();
 
 module.exports = initializer;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "messagemedia-messages-sdk",
+  "name": "@localz/messagemedia-messages-sdk",
   "version": "1.0.0",
   "description": "The MessageMedia Messages API provides a number of endpoints for building powerful two-way messaging applications.",
   "main": "./lib/index.js",


### PR DESCRIPTION
Modifying the existing MessageMedia NodeJS SDK to prevent it from rewriting our existing logging config settings (i.e. prevent it from writing to a file for all of our logging) and so that we can only show error messages (instead of the info messages).

Changes:
- Modifying LogConfig to create a new `winston` container to seperate the configuration between MessageMedia SDK and our services.
- Controllers use the `winston` container via the static `getLogger()` method.
- You can set the logging level at runtime via the static `setLogLevel()` method.