### PR TITLE
[fix] confirmation requests do not return JSON bodies

### DIFF
--- a/lib/Controllers/DeliveryReportsController.js
+++ b/lib/Controllers/DeliveryReportsController.js
@@ -213,9 +213,8 @@ class DeliveryReportsController {
                     _callback(errorResponse.error, errorResponse.response, errorResponse.context);
                     _reject(errorResponse.error);
                 } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
-                    const parsed = JSON.parse(_response.body);
-                    _callback(null, parsed, _context);
-                    _fulfill(parsed);
+                    _callback(null, {}, _context);
+                    _fulfill({});
                 } else {
                     errorResponse = _baseController.validateResponse(_context);
                     _callback(errorResponse.error, errorResponse.response, errorResponse.context);

--- a/lib/Controllers/RepliesController.js
+++ b/lib/Controllers/RepliesController.js
@@ -217,9 +217,8 @@ class RepliesController {
                     _callback(errorResponse.error, errorResponse.response, errorResponse.context);
                     _reject(errorResponse.error);
                 } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
-                    const parsed = JSON.parse(_response.body);
-                    _callback(null, parsed, _context);
-                    _fulfill(parsed);
+                    _callback(null, {}, _context);
+                    _fulfill({});
                 } else {
                     errorResponse = _baseController.validateResponse(_context);
                     _callback(errorResponse.error, errorResponse.response, errorResponse.context);


### PR DESCRIPTION
Because the API does not return JSON bodies for these two requests, the API crashes node with `SyntaxError: Unexpected end of JSON input` 